### PR TITLE
Add Terms of Service link to privacy.php

### DIFF
--- a/Src/privacy.php
+++ b/Src/privacy.php
@@ -574,6 +574,11 @@
                                                                                     Privacy notice
                                                                                 </a>
                                                                             </li>
+                                                                            <li>
+                                                                                <a href="https://bot.straccini.com/tos.php">
+                                                                                    Terms of Service
+                                                                                </a>
+                                                                            </li>
                                                                         </ul>  
                                                                     </td>
                                                                 </tr>


### PR DESCRIPTION
### **Description**
- Introduced a new link to the Terms of Service in the privacy page.
- Improved user navigation by providing direct access to important legal documents.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>privacy.php</strong><dd><code>Add Terms of Service link to privacy page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/privacy.php
<li>Added a new link to the Terms of Service.<br> <li> Enhanced the privacy notice section.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-website/pull/60/files#diff-0c35528ee47b3bf0393000fd3fd5cb648f6a201d90a8611f4adad01057c3babf">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>