### PR TITLE
Add Terms of Service link to status.php

### DIFF
--- a/Src/status.php
+++ b/Src/status.php
@@ -560,6 +560,11 @@
                                                                                     Privacy notice
                                                                                 </a>
                                                                             </li>
+                                                                            <li>
+                                                                                <a href="https://bot.straccini.com/tos.php">
+                                                                                    Terms of Service
+                                                                                </a>
+                                                                            </li>
                                                                         </ul>  
                                                                     </td>
                                                                 </tr>


### PR DESCRIPTION
### **Description**
- Introduced a new link to the Terms of Service in the `status.php` file.
- This enhancement improves user access to legal information.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>status.php</strong><dd><code>Add Terms of Service link to status page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/status.php
<li>Added a new link for Terms of Service.<br> <li> Enhanced the footer section of the page.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-website/pull/61/files#diff-4c3082d6f58b07684decc09da07fd952f8a97a8563f7295d4db7ea90f3363f0a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>