### PR TITLE
feat - Added 'private' status display to dashboard.

### DIFF
--- a/Src/dashboard.php
+++ b/Src/dashboard.php
@@ -241,8 +241,9 @@ $title = "Dashboard";
                                 <td><?php echo htmlspecialchars($repo['organization']) ?></td>
                                 <td><a href='<?php echo $repo['url']; ?>'><?php echo htmlspecialchars($repo['name']); ?></a>
                                 </td>
-                                <td><?php echo $repo['fork'] ? '<i class="fas fa-circle-check status-success"></i> Yes' : '<i class="fas fa-circle-xmark status-failed"></i> No'; ?></td>
+                                <td><?php echo $repo['private'] ? '<i class="fas fa-circle-check status-success"></i> Yes' : '<i class="fas fa-circle-xmark status-failed"></i> No'; ?></td>
                                 <td><i class="fas fa-star"></i> <?php echo $repo['stars']; ?></td>
+                                <td><?php echo $repo['fork'] ? '<i class="fas fa-circle-check status-success"></i> Yes' : '<i class="fas fa-circle-xmark status-failed"></i> No'; ?></td>
                                 <td><i class="fas fa-code-branch"></i> <?php echo $repo['forks']; ?></td>
                                 <td><i class="fas fa-circle-exclamation"></i> <?php echo $repo['issues']; ?></td>
                                 <td><i class="fas fa-code-pull-request"></i> <?php echo $repo['pull_requests']; ?></td>
@@ -316,9 +317,10 @@ $title = "Dashboard";
                 <td>${repo.organization}</td>
                 <td><a href='${repo.url}'>${repo.name}</a></a>
                 </td>
-                <td>${repo.fork ? '<i class="fas fa-circle-check status-success"></i> Yes' : '<i class="fas fa-circle-xmark status-failed"></i> No'}
+                <td>${repo.private ? '<i class="fas fa-circle-check status-success"></i> Yes' : '<i class="fas fa-circle-xmark status-failed"></i> No'}
                 </td>
                 <td><i class="fas fa-star"></i> ${repo.stars}</td>
+                <td>${repo.fork ? '<i class="fas fa-circle-check status-success"></i> Yes' : '<i class="fas fa-circle-xmark status-failed"></i> No'}
                 <td><i class="fas fa-code-branch"></i> ${repo.forks}</td>
                 <td><i class="fas fa-circle-exclamation"></i> ${repo.issues}</td>
                 <td><i class="fas fa-code-pull-request"></i> ${repo.pull_requests}</td>


### PR DESCRIPTION
### **User description**
<!-- 
Thanks for creating this pull request 🤗

Please limit the pull request to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- 
You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ☢️ Does this introduce a breaking change?
<!-- If this introduces a breaking change, make sure to note it here and what the impact might be -->
- [ ] Yes
- [ ] No

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.-->


___

### **Description**
- Added display for repository `private` status on the dashboard.
- Updated the logic to reflect the correct status for both `fork` and `private` properties.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.php</strong><dd><code>Enhance Dashboard with Private Status Display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/dashboard.php
<li>Updated the dashboard to display the 'private' status of repositories.<br> <li> Modified the logic to show 'Yes' or 'No' based on the <code>private</code> <br>property.<br> <li> Adjusted the display for both <code>fork</code> and <code>private</code> statuses.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-website/pull/195/files#diff-55feb1b791e2d08f4e56bc190d560fdb732da7f81db363c6d25fb0c8033a95c0">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

