### PR TITLE
[FEATURE] Persist and list organizations in account page

### DIFF
--- a/Src/account.php
+++ b/Src/account.php
@@ -45,6 +45,32 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     exit();
 }
 
+if (!isset($_SESSION['organizations'])) {
+    $token = $_SESSION['token'];
+    $apiUrl = "https://api.github.com/user/orgs";
+
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $apiUrl);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        "Authorization: Bearer $token",
+        "User-Agent: GStraccini-Bot/1.0 (+https://github.com/guibranco/gstraccini-bot-website)"
+    ]);
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($httpCode === 200) {
+        $organizations = json_decode($response, true);
+        $_SESSION['organizations'] = $organizations;
+    } else {
+        $organizations = [];
+        $_SESSION['organizations'] = [];
+    }
+} else {
+    $organizations = $_SESSION['organizations'];
+}
+
 $title = "Account Details";
 ?>
 
@@ -181,6 +207,31 @@ $title = "Account Details";
                         <a href="dashboard.php" class="btn btn-secondary"><i class="fas fa-times"></i> Cancel</a>
                     </div>
                 </form>
+            </div>
+        </div>
+
+        <div class="row mt-5">
+            <div class="col-md-8 offset-md-2">
+                <div class="card">
+                    <div class="card-header">
+                        <h3>Organizations</h3>
+                    </div>
+                    <div class="card-body">
+                        <?php if (!empty($organizations)): ?>
+                            <ul class="list-group">
+                                <?php foreach ($organizations as $org): ?>
+                                    <li class="list-group-item d-flex align-items-center">
+                                        <img src="<?php echo htmlspecialchars($org['avatar_url']); ?>" alt="Avatar"
+                                             class="rounded-circle me-3" width="40" height="40">
+                                        <span><?php echo htmlspecialchars($org['login']); ?></span>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php else: ?>
+                            <p class="text-muted">No organizations found or granted access.</p>
+                        <?php endif; ?>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## 📑 Description
This pull request adds functionality to persist user organizations in a session variable. Organizations are fetched via the GitHub API only if the session is empty, improving efficiency by reducing redundant API calls. 

Additionally, a new section has been added to the `account.php` page to display the user's organizations, including their avatars and names, styled using Bootstrap.

### Changes
- [x] Persist user organizations in `$_SESSION['organizations']`.  
- [x] Fetch organizations from the GitHub API only when the session is empty.  
- [x] Add a new section to `account.php` listing organizations with avatars and names.  
- [x] Handle empty organizations gracefully with a fallback message.  
- [x] Update session logic for efficient re-fetching when logging in/out.  

## ✅ Checks
- [x] My pull request adheres to the code style of this project  
- [ ] My code requires changes to the documentation  
- [ ] I have updated the documentation as required  
- [x] All the tests have passed  

## ☢️ Does this introduce a breaking change?
- [ ] Yes  
- [x] No  

## ℹ Additional Information
- **GitHub API endpoint:** `https://api.github.com/user/orgs`  
- Organizations list includes avatars (via `avatar_url`) and names.  
- Fallback message: "No organizations found or granted access."  
- Tested for scenarios with and without organizations, and session resets.

## Summary by Sourcery

Add organization persistence and display to the account page. Fetch user organizations from the GitHub API and store them in the session. Display the organizations with their avatars and names in a new section on the account page.

New Features:
- Display user organizations on the account page, including their avatars and names.

Tests:
- Test organization fetching and display with and without organizations present, as well as session resets.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Integrate functionality to persist and display a user's organizations on the account page by fetching organization data from GitHub's API and storing it in the session.

### Why are these changes being made?

To enhance the user experience by allowing users to view their GitHub organizations directly from the account page. This improves data accessibility and user engagement with the application, leveraging stored sessions to minimize repeated API calls. This approach presumes authorized access, optimizing user interactions while preserving performance.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->