### PR TITLE
Update pull-requests.php

### DIFF
--- a/src/pull-requests.php
+++ b/src/pull-requests.php
@@ -66,7 +66,7 @@ function getMergeableBadge($mergeable, $mergeable_state) {
         } else if ($mergeable_state === 'blocked') {
             return '<span class="badge bg-warning text-dark"><i class="fas fa-lock"></i> Blocked</span>';
         } else if ($mergeable_state === 'behind') {
-            return '<span class="badge bg-warning text-dark"><i class="fas fa-arrow-circle-down"></i> Behind</span>';
+            return '<span class="badge bg-secondary"><i class="fas fa-arrow-circle-down"></i> Behind</span>';
         } else if ($mergeable_state === 'dirty') {
             return '<span class="badge bg-danger"><i class="fas fa-exclamation-circle"></i> Dirty</span>';
         } else {
@@ -423,7 +423,7 @@ function isValidPR($pr) {
                 } else if (mergeable_state === 'blocked') {
                     return '<span class="badge bg-warning text-dark"><i class="fas fa-lock"></i> Blocked</span>';
                 } else if (mergeable_state === 'behind') {
-                    return '<span class="badge bg-warning text-dark"><i class="fas fa-arrow-circle-down"></i> Behind</span>';
+                    return '<span class="badge bg-secondary"><i class="fas fa-arrow-circle-down"></i> Behind</span>';
                 } else if (mergeable_state === 'dirty') {
                     return '<span class="badge bg-danger"><i class="fas fa-exclamation-circle"></i> Dirty</span>';
                 } else {


### PR DESCRIPTION
### **User description**
## 📑 Description
Update pull-requests.php

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Enhanced the visual representation of the 'behind' state in pull requests by changing the badge color to `bg-secondary`.
- This change improves the clarity of the badge status in the user interface.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pull-requests.php</strong><dd><code>Update badge color for 'behind' state in pull-requests.php</code></dd></summary>
<hr>

src/pull-requests.php
<li>Updated the badge color for the 'behind' state from bg-warning to <br>bg-secondary.<br> <li> Applied the same change in two locations within the file.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot-website/pull/480/files#diff-92b95da195143a8e9043bc5f8e2a37c78f14817639fd8c91ceb26a63bb58a696">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the badge color for the "behind" mergeable state to use a secondary background for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->