### PR TITLE
[FEATURE] Dynamically load commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           cd src
           echo "<?php" >> webhook.secrets.php
-          echo "\$gstracciniApiUrl      = \"${{ secrets.GSTRACCINI_API_HEALTHCHECK_URL }}\";" >> webhook.secrets.php
+          echo "\$gstracciniApiUrl      = \"${{ secrets.GSTRACCINI_API }}\";" >> webhook.secrets.php
           echo "\$webhookSecret         = \"${{ secrets.WEBHOOK_SECRET }}\";" >> webhook.secrets.php
           echo "\$webhookUrl            = \"${{ secrets.WEBHOOK_URL }}\";" >> webhook.secrets.php
           echo "\$webhooksProcessingUrl = \"${{ secrets.WEBHOOK_PROCESSING_HEALTHCHECK_URL }}\";" >> webhook.secrets.php

--- a/src/api/v1/api-commands.php
+++ b/src/api/v1/api-commands.php
@@ -1,6 +1,4 @@
 <?php
-<?php
-
 if (!file_exists("../../webhook.secrets.php")) {
     http_response_code(500);
     die(json_encode(['error' => 'Configuration file not found']));

--- a/src/api/v1/api-commands.php
+++ b/src/api/v1/api-commands.php
@@ -1,0 +1,49 @@
+<?php
+<?php
+
+if (!file_exists("../../webhook.secrets.php")) {
+    http_response_code(500);
+    die(json_encode(['error' => 'Configuration file not found']));
+}
+require_once "../../webhook.secrets.php";
+
+header('Content-Type: application/json');
+header('Cache-Control: public, max-age=300');
+
+$url = $gstracciniApiUrl."v1/commands?format=json";
+
+$curl = curl_init();
+curl_setopt_array($curl, [
+    CURLOPT_URL => $url,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_TIMEOUT => 10,
+    CURLOPT_CONNECTTIMEOUT => 5,
+    CURLOPT_USERAGENT => 'GStraccini-bot-website/1.0 (+https://github.com/guibranco/gstraccini-bot-website)',
+    CURLOPT_HTTPHEADER => ['Accept: application/json'],
+]);
+
+$response = curl_exec($curl);
+$httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+$curlError = curl_error($curl);
+curl_close($curl);
+
+if ($response === false || $curlError) {
+    http_response_code(502);
+    echo json_encode(['error' => 'Failed to fetch commands: ' . $curlError]);
+    exit();
+}
+
+if ($httpCode !== 200) {
+    http_response_code(502);
+    echo json_encode(['error' => "Upstream returned HTTP $httpCode"]);
+    exit();
+}
+
+$decoded = json_decode($response);
+if ($decoded === null) {
+    http_response_code(502);
+    echo json_encode(['error' => 'Invalid JSON from upstream']);
+    exit();
+}
+
+echo json_encode($decoded);

--- a/src/api/v1/service-status.php
+++ b/src/api/v1/service-status.php
@@ -63,7 +63,7 @@ function checkServiceHealth(string $url): array
 }
 
 try {
-    $resultApi = checkServiceHealth($gstracciniApiUrl);
+    $resultApi = checkServiceHealth($gstracciniApiUrl."v1/health");
 } catch (Exception $e) {
     error_log("Health check handler failed: " . $e->getMessage());
     $resultApi = [

--- a/src/index.php
+++ b/src/index.php
@@ -10,6 +10,7 @@ require_once "includes/session.php";
   <meta name="description" content="Introducing Your GStraccini-bot - Automate GitHub tasks with ease.">
   <title>GStraccini Bot | Automate Your Workflow</title>
   <link rel="stylesheet" href="/static/main.css" />
+  <script src="/static/commands.js" defer></script>
 </head>
 
 <body>
@@ -75,104 +76,7 @@ require_once "includes/session.php";
 
   <section class="commands fade-in">
     <h2>Available Commands</h2>
-    <div class="commands-grid">
-      <div class="command-card">
-        <strong>@gstraccini help</strong>
-        <p>Shows the help message with available commands.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini add project &lt;projectPath&gt;</strong>
-        <p>Adds a project to the solution file (only for .NET projects).</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini appveyor build &lt;type&gt;</strong>
-        <p>Runs the AppVeyor build for the target commit and/or pull request.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini appveyor bump version &lt;component&gt;</strong>
-        <p>Bumps the CI version in AppVeyor.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini appveyor register</strong>
-        <p>Registers the repository in AppVeyor.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini appveyor reset</strong>
-        <p>Resets the AppVeyor build number for the target repository.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini bump version &lt;version&gt; &lt;project&gt;</strong>
-        <p>Bumps the .NET version in .csproj files. ⚠️ (In development, it may not work as expected!)</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini cargo clippy</strong>
-        <p>Formats the Rust code using Cargo Clippy (only for Rust projects).</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini change runner &lt;runner&gt; &lt;workflow&gt; &lt;jobs&gt;</strong>
-        <p>Changes the GitHub action runner in a workflow file (.yml). ⚠️ (In development, it may not work as expected!)</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini codacy bypass</strong>
-        <p>Bypasses the Codacy analysis for the target commit and/or pull request.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini codacy reanalyze commit</strong>
-        <p>Reanalyzes the Codacy last commit in a pull request.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini codeclimate bypass</strong>
-        <p>Bypasses the CodeClimate analysis for the target commit and/or pull request.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini copy labels &lt;repository&gt;</strong>
-        <p>Copy the labels from another repository.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini copy issue &lt;repository&gt;</strong>
-        <p>Copy an issue from one repository to another ⚠️ (In development, it may not work as expected!)</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini create labels &lt;style&gt; &lt;categories&gt;</strong>
-        <p>Create the default labels in the repository.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini csharpier</strong>
-        <p>Formats the C# code using CSharpier (only for .NET projects).</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini fix csproj</strong>
-        <p>Updates the .csproj file with the packages.config version of NuGet packages (only for .NET Framework projects). ⚠️ (In development, it may not work as expected!)</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini npm check updates</strong>
-        <p>Update dependencies in a package.json and package-lock.json using the npm-check-updates (only for NPM projects).</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini npm dist</strong>
-        <p>Generate or regenerate the dist files. It will run the following NPM command: npm run package.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini prettier</strong>
-        <p>Formats the code using Prettier.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini rerun checks &lt;conclusion&gt;</strong>
-        <p>This option reruns the checks in the target pull request upon current status.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini rerun workflows &lt;conclusion&gt;</strong>
-        <p>This option reruns the workflows (action) in the target pull request. It is only available for GitHub Actions!</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini review</strong>
-        <p>Enable review for the target pull request. This is useful when the PR submitter wasn't on the watch list, the webhook was not captured, or some failed scenario occurred.</p>
-      </div>
-      <div class="command-card">
-        <strong>@gstraccini update snapshot</strong>
-        <p>Update test snapshots (npm test -- -u) (only for Node.js projects).</p>
-      </div>
-    </div>
+    <div class="commands-grid"></div>
   </section>
 
   <?php require_once "includes/footer-public.php"; ?>

--- a/src/static/commands.js
+++ b/src/static/commands.js
@@ -1,0 +1,62 @@
+/**
+ * Converts a subset of Markdown to safe HTML.
+ * Handles: [text](url), **text**, `code`, and **.NET** style bold.
+ */
+function renderMarkdown(text) {
+    return text
+        .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+        .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+        .replace(/`([^`]+)`/g, '<code>$1</code>');
+}
+
+function buildSignature(command, parameters) {
+    let sig = '@gstraccini ' + command;
+    if (Array.isArray(parameters)) {
+        for (const p of parameters) {
+            sig += p.required ? ' &lt;' + p.parameter + '&gt;' : ' [' + p.parameter + ']';
+        }
+    }
+    return sig;
+}
+
+function createCommandCard(cmd) {
+    const card = document.createElement('div');
+    card.className = 'command-card';
+
+    const title = document.createElement('strong');
+    title.innerHTML = buildSignature(cmd.command, cmd.parameters);
+    card.appendChild(title);
+
+    const desc = document.createElement('p');
+    let descHtml = renderMarkdown(cmd.description);
+    if (cmd.dev) {
+        descHtml += ' <span class="dev-badge">&#9888;&#xFE0F; In development &mdash; may not work as expected</span>';
+    }
+    desc.innerHTML = descHtml;
+    card.appendChild(desc);
+
+    return card;
+}
+
+async function loadCommands() {
+    const grid = document.querySelector('.commands-grid');
+    if (!grid) return;
+
+    grid.innerHTML = '<p class="commands-loading">Loading commands&hellip;</p>';
+
+    try {
+        const response = await fetch('/api/v1/api-commands.php');
+        if (!response.ok) throw new Error('HTTP ' + response.status);
+        const commands = await response.json();
+
+        grid.innerHTML = '';
+        for (const cmd of commands) {
+            grid.appendChild(createCommandCard(cmd));
+        }
+    } catch (err) {
+        grid.innerHTML = '<p class="commands-error">Failed to load commands. Please try again later.</p>';
+        console.error('Commands fetch error:', err);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', loadCommands);

--- a/src/static/main.css
+++ b/src/static/main.css
@@ -247,6 +247,25 @@ img.octocat {
   color: #555;
 }
 
+.commands-loading,
+.commands-error {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 20px;
+  color: #555;
+}
+
+.commands-error {
+  color: #dc3545;
+}
+
+.dev-badge {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 0.85em;
+  color: #856404;
+}
+
 section.content {
   padding: 20px;
   max-width: 800px;


### PR DESCRIPTION
## 📑 Description
[FEATURE] Dynamically load commands

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Load the public commands list dynamically from the backend API instead of hardcoding it in the landing page.

New Features:
- Expose a new /api/v1/api-commands.php endpoint that proxies and validates command definitions from the GStraccini API.
- Render command cards on the frontend by fetching command metadata via JavaScript and converting basic Markdown to HTML, including a development-status badge.

Enhancements:
- Simplify the landing page commands section to an empty grid that is populated at runtime and add styles for loading, error states, and a development badge.
- Update the service status health check to target the v1/health path on the GStraccini API.

Build:
- Adjust deploy workflow to use the primary GSTRACCINI_API secret for the webhook API URL instead of the healthcheck-specific secret.