### PR TITLE
refactor: centralize User-Agent logic in constants.php

### DIFF
--- a/src/api/v1/api-commands.php
+++ b/src/api/v1/api-commands.php
@@ -4,6 +4,7 @@ if (!file_exists("../../webhook.secrets.php")) {
     die(json_encode(['error' => 'Configuration file not found']));
 }
 require_once "../../webhook.secrets.php";
+require_once "../../includes/constants.php";
 
 header('Content-Type: application/json');
 header('Cache-Control: public, max-age=300');
@@ -18,7 +19,7 @@ curl_setopt_array($curl, [
     CURLOPT_MAXREDIRS => 3,
     CURLOPT_TIMEOUT => 10,
     CURLOPT_CONNECTTIMEOUT => 5,
-    CURLOPT_USERAGENT => 'GStraccini-bot-website/1.0 (+https://github.com/guibranco/gstraccini-bot-website)',
+    CURLOPT_USERAGENT => getUserAgent(),
     CURLOPT_HTTPHEADER => ['Accept: application/json'],
 ]);
 

--- a/src/api/v1/service-status.php
+++ b/src/api/v1/service-status.php
@@ -5,6 +5,7 @@ if (!file_exists("../../webhook.secrets.php")) {
     die(json_encode(['error' => 'Configuration file not found']));
 }
 require_once "../../webhook.secrets.php";
+require_once "../../includes/constants.php";
 
 /**
  * Performs an HTTP GET request and checks the response.
@@ -26,7 +27,7 @@ function checkServiceHealth(string $url): array
         CURLOPT_TIMEOUT => 10,
         CURLOPT_SSL_VERIFYPEER => true,
         CURLOPT_SSL_VERIFYHOST => 2,
-        CURLOPT_USERAGENT => 'GStraccini-bot-website/1.0 (+https://github.com/guibranco/gstraccini-bot-website)',
+        CURLOPT_USERAGENT => getUserAgent(),
     ]);
 
     $response = curl_exec($curl);

--- a/src/callback.php
+++ b/src/callback.php
@@ -1,5 +1,6 @@
 <?php
 require_once "includes/session.php";
+require_once "includes/constants.php";
 require_once "github.secrets.php";
 require_once "webhook.secrets.php";
 
@@ -14,8 +15,7 @@ class GitHubOAuthHandler
 {
     private const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
     private const GITHUB_API_BASE = 'https://api.github.com';
-    private const USER_AGENT = 'GStraccini-bot-website/1.0 (+https://github.com/guibranco/gstraccini-bot-website)';
-    
+
     private string $clientId;
     private string $clientSecret;
     private string $redirectUri;
@@ -54,7 +54,7 @@ class GitHubOAuthHandler
         
         $headers = [
             'Accept: application/json',
-            'User-Agent: ' . self::USER_AGENT,
+            'User-Agent: ' . getUserAgent(),
             'Content-Type: application/x-www-form-urlencoded'
         ];
         
@@ -76,7 +76,7 @@ class GitHubOAuthHandler
         $url = self::GITHUB_API_BASE . $endpoint;
         $headers = [
             "Authorization: Bearer {$token}",
-            "User-Agent: " . self::USER_AGENT,
+            "User-Agent: " . getUserAgent(),
             "Accept: application/vnd.github+json",
             "X-GitHub-Api-Version: 2022-11-28"
         ];
@@ -162,7 +162,7 @@ class GitHubOAuthHandler
         
         $headers = [
             'Content-Type: application/json',
-            'User-Agent: ' . self::USER_AGENT,
+            'User-Agent: ' . getUserAgent(),
             'Authorization: token ' . $this->webhookSecret
         ];
         

--- a/src/includes/constants.php
+++ b/src/includes/constants.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Application-wide constants and helpers.
+ */
+
+const APP_REPOSITORY_URL = 'https://github.com/guibranco/gstraccini-bot-website';
+
+/**
+ * Reads the application version written to version.txt during deployment.
+ *
+ * @return string The application version, or "dev" if version.txt is not present.
+ */
+function getAppVersion(): string
+{
+    static $version = null;
+
+    if ($version !== null) {
+        return $version;
+    }
+
+    $versionFile = __DIR__ . '/../version.txt';
+    $version = file_exists($versionFile) ? trim(file_get_contents($versionFile)) : 'dev';
+
+    return $version;
+}
+
+/**
+ * Builds the User-Agent string used for all outgoing HTTP requests.
+ *
+ * @return string The User-Agent string.
+ */
+function getUserAgent(): string
+{
+    return 'GStraccini-bot-website/' . getAppVersion() . ' (+' . APP_REPOSITORY_URL . ')';
+}

--- a/src/includes/github-api.php
+++ b/src/includes/github-api.php
@@ -5,6 +5,8 @@
  * Contains utility functions for interacting with the GitHub API.
  */
 
+require_once __DIR__ . '/constants.php';
+
 /**
  * Load data from the GitHub API
  *
@@ -27,7 +29,7 @@ function loadData($url, $token)
         CURLOPT_HEADER => true,
         CURLOPT_HTTPHEADER => [
             "Authorization: Bearer $token",
-            "User-Agent: GStraccini-bot-website/1.0 (+https://github.com/guibranco/gstraccini-bot-website)",
+            "User-Agent: " . getUserAgent(),
             "Accept: application/vnd.github+json",
             "X-GitHub-Api-Version: 2022-11-28",
         ],


### PR DESCRIPTION
## 📑 Description
Introduce getUserAgent() in a new constants.php to streamline the User-Agent construction and manage it centrally. Replace hardcoded User-Agent strings across various files with calls to getUserAgent(). This change ensures consistent User-Agent strings across the application and simplifies version management via a centralized location. Additionally, include constants.php in relevant files for accessibility. This approach enhances maintainability and adheres to DRY principles.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Centralize construction of the HTTP User-Agent string and application version into a shared constants module for consistent usage across the codebase.

Enhancements:
- Introduce a shared constants.php helper that exposes the application repository URL, resolves the deployed version from version.txt, and builds a standardized User-Agent string.
- Update GitHub OAuth, GitHub API utilities, and v1 API endpoints to use the centralized getUserAgent() helper instead of hardcoded User-Agent values.