### PR TITLE
fix: scope stats API call by user id and API key

### DIFF
--- a/src/api/v1/api-stats.php
+++ b/src/api/v1/api-stats.php
@@ -1,18 +1,30 @@
 <?php
 /**
- * API endpoint for GStraccini-Bot usage statistics (public, unauthenticated)
+ * API endpoint for the signed-in user's usage statistics, scoped to their
+ * GitHub user id.
  */
 
-if (!file_exists("../../webhook.secrets.php")) {
+if (file_exists("../../webhook.secrets.php") === false) {
     http_response_code(500);
     die(json_encode(['error' => 'Configuration file not found']));
 }
+
 require_once "../../webhook.secrets.php";
 require_once "../../includes/constants.php";
 require_once "../../includes/log-stream.php";
 require_once "../../includes/remote-json-proxy.php";
+require_once "../../includes/session.php";
+require_once "../../includes/user-scope.php";
+
+if ($isAuthenticated === false) {
+    http_response_code(401);
+    echo json_encode(['error' => 'User not authenticated.']);
+    exit();
+}
 
 header('Content-Type: application/json');
-header('Cache-Control: public, max-age=300');
+header('Cache-Control: private, max-age=300');
 
-proxyJsonFromUpstream($gstracciniApiUrl . "v1/stats/", 'stats');
+$url = appendUserIdParam($gstracciniApiUrl."v1/stats/", getCurrentUserId());
+
+proxyJsonFromUpstream($url, 'stats', ["X-Api-Key: $gstracciniApiKey"]);


### PR DESCRIPTION
## Summary
- `/v1/stats/` requires `userId` (query) and `X-Api-Key` (header) per the gstraccini-bot-service OpenAPI spec, same as `/v1/notifications/` and `/v1/pending-actions/` (#666).
- `api-stats.php` was missed in that pass and still called upstream unauthenticated, causing HTTP 401 on the dashboard's stats tiles.
- Also switched `Cache-Control` from `public` to `private`, since the response is now per-user rather than shared/global.

## Test plan
- [x] `php -l src/api/v1/api-stats.php`
- [x] Diff reviewed against the already-merged `notifications.php`/`pending-actions.php` pattern (#666) for consistency
- [ ] Confirm stats tiles load without 401 on the dashboard after this deploys (requires `GSTRACCINI_API_KEY` secret, already added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Scope the stats API endpoint to the authenticated GitHub user and align it with existing authenticated upstream calls.

Bug Fixes:
- Fix unauthenticated upstream call from the stats API that caused HTTP 401 errors on dashboard stats tiles.

Enhancements:
- Change stats API cache headers from public to private to reflect per-user responses.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR scopes the stats API endpoint to the authenticated user by adding a session/auth guard, appending the `userId` query parameter, and forwarding the `X-Api-Key` header to the upstream service — bringing `api-stats.php` in line with the `notifications.php`/`pending-actions.php` pattern from #666. It also correctly flips `Cache-Control` from `public` to `private` now that the response is per-user.

- **Auth guard added**: endpoint now returns 401 immediately when `$isAuthenticated` is false, preventing unauthenticated upstream calls that caused HTTP 401 on the dashboard.
- **Upstream URL scoped**: `appendUserIdParam` appends `?userId=X` and the `X-Api-Key` header is forwarded via `proxyJsonFromUpstream`, matching the existing pattern exactly.
- **Cache-Control corrected**: changed from `public, max-age=300` to `private, max-age=300` since the response is now user-specific and should not be shared by intermediary caches.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change directly fixes unauthenticated upstream calls and is a faithful port of the already-reviewed notifications/pending-actions pattern.

The logic is straightforward and consistent with the established pattern. The only wrinkle is that the 401 error response is emitted before the Content-Type header is set, a minor inconsistency that exists in the sibling endpoints as well.

Only src/api/v1/api-stats.php changed; the one thing worth a second look is the header ordering around the auth block (lines 19–25).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/api/v1/api-stats.php | Adds auth guard, userId scoping, and X-Api-Key header to match the notifications/pending-actions pattern; switches Cache-Control from public to private. Minor: the 401 error response lacks a Content-Type header. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant api-stats.php
    participant session.php
    participant user-scope.php
    participant upstream as gstraccini-bot-service

    Browser->>api-stats.php: GET /api/v1/api-stats.php
    api-stats.php->>session.php: require_once (sets $isAuthenticated)
    api-stats.php->>user-scope.php: require_once (provides getCurrentUserId, appendUserIdParam)

    alt Not authenticated
        api-stats.php-->>Browser: "401 {error: User not authenticated.}"
    else Authenticated
        api-stats.php->>user-scope.php: "getCurrentUserId() → int|null"
        api-stats.php->>user-scope.php: "appendUserIdParam(url, userId) → url?userId=X"
        api-stats.php->>upstream: "GET v1/stats/?userId=X + X-Api-Key header"
        alt Upstream OK (200)
            upstream-->>api-stats.php: JSON stats payload
            api-stats.php-->>Browser: "200 JSON (Cache-Control: private, max-age=300)"
        else Upstream error
            upstream-->>api-stats.php: non-200 or curl failure
            api-stats.php-->>Browser: "502 {error: ...}"
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant api-stats.php
    participant session.php
    participant user-scope.php
    participant upstream as gstraccini-bot-service

    Browser->>api-stats.php: GET /api/v1/api-stats.php
    api-stats.php->>session.php: require_once (sets $isAuthenticated)
    api-stats.php->>user-scope.php: require_once (provides getCurrentUserId, appendUserIdParam)

    alt Not authenticated
        api-stats.php-->>Browser: "401 {error: User not authenticated.}"
    else Authenticated
        api-stats.php->>user-scope.php: "getCurrentUserId() → int|null"
        api-stats.php->>user-scope.php: "appendUserIdParam(url, userId) → url?userId=X"
        api-stats.php->>upstream: "GET v1/stats/?userId=X + X-Api-Key header"
        alt Upstream OK (200)
            upstream-->>api-stats.php: JSON stats payload
            api-stats.php-->>Browser: "200 JSON (Cache-Control: private, max-age=300)"
        else Upstream error
            upstream-->>api-stats.php: non-200 or curl failure
            api-stats.php-->>Browser: "502 {error: ...}"
        end
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fapi%2Fv1%2Fapi-stats.php%3A19-25%0AThe%20401%20error%20response%20echoes%20a%20JSON%20body%20but%20no%20%60Content-Type%3A%20application%2Fjson%60%20header%20has%20been%20sent%20yet%20at%20that%20point%2C%20since%20the%20header%20call%20is%20after%20the%20auth%20block.%20Clients%20that%20inspect%20the%20content-type%20%28e.g.%20fetch%20wrappers%20that%20check%20%60response.headers.get%28'content-type'%29%60%29%20may%20mishandle%20the%20response.%20The%20same%20pattern%20exists%20in%20%60notifications.php%60%20and%20%60pending-actions.php%60%2C%20so%20this%20is%20a%20good%20moment%20to%20fix%20it%20consistently.%0A%0A%60%60%60suggestion%0Aheader%28'Content-Type%3A%20application%2Fjson'%29%3B%0A%0Aif%20%28%24isAuthenticated%20%3D%3D%3D%20false%29%20%7B%0A%20%20%20%20http_response_code%28401%29%3B%0A%20%20%20%20echo%20json_encode%28%5B'error'%20%3D%3E%20'User%20not%20authenticated.'%5D%29%3B%0A%20%20%20%20exit%28%29%3B%0A%7D%0A%60%60%60%0A%0A&repo=guibranco%2Fgstraccini-bot-website&pr=668&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/api/v1/api-stats.php:19-25
The 401 error response echoes a JSON body but no `Content-Type: application/json` header has been sent yet at that point, since the header call is after the auth block. Clients that inspect the content-type (e.g. fetch wrappers that check `response.headers.get('content-type')`) may mishandle the response. The same pattern exists in `notifications.php` and `pending-actions.php`, so this is a good moment to fix it consistently.

```suggestion
header('Content-Type: application/json');

if ($isAuthenticated === false) {
    http_response_code(401);
    echo json_encode(['error' => 'User not authenticated.']);
    exit();
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: scope stats API call by user id and..."](https://github.com/guibranco/gstraccini-bot-website/commit/8d2975c4360c6003409eb812c50d23ed7902629c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45977911)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Usage statistics are now available only to authenticated users.
  * Unauthenticated requests receive a clear authorization error.
  * Statistics are scoped to the signed-in user.
  * Responses are no longer publicly cacheable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->